### PR TITLE
Add example link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ A demo site is available at: http://www.gatsbyplugins.com
 
 This demo site contain detailed information about how to use the plugin.
 
+## Example
+
+Check out the example repository here: https://github.com/pcarion/gatsby-source-notionso-example
+
 ## Installation
 ```sh
 $ npm install --save gatsby-source-notionso


### PR DESCRIPTION
I was confused because I thought there used to be an example of using the app. Searching "example" on the page returned zero results. After finding the issue and later the commit that moved the example I found the other repo.

Hopefully linking to the example will help others find it.